### PR TITLE
Add links to runtime libraries on GitHub

### DIFF
--- a/index.md
+++ b/index.md
@@ -407,15 +407,15 @@ sudo apt-get install kaitai-struct-compiler</pre>
       <li>
         Runtime libraries:
         <ul>
-          <li>C++/STL — MIT</li>
-          <li>C# — MIT</li>
-          <li>Java — MIT</li>
-          <li>JavaScript — Apache v2</li>
-          <li>Lua — MIT</li>
-          <li>Perl — MIT</li>
-          <li>PHP — MIT</li>
-          <li>Python — MIT</li>
-          <li>Ruby — MIT</li>
+          <li><a href="https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime">C++/STL</a> — MIT</li>
+          <li><a href="https://github.com/kaitai-io/kaitai_struct_csharp_runtime">C#</a> — MIT</li>
+          <li><a href="https://github.com/kaitai-io/kaitai_struct_java_runtime">Java</a> — MIT</li>
+          <li><a href="https://github.com/kaitai-io/kaitai_struct_javascript_runtime">JavaScript</a> — Apache v2</li>
+          <li><a href="https://github.com/kaitai-io/kaitai_struct_lua_runtime">Lua</a> — MIT</li>
+          <li><a href="https://github.com/kaitai-io/kaitai_struct_perl_runtime">Perl</a> — MIT</li>
+          <li><a href="https://github.com/kaitai-io/kaitai_struct_php_runtime">PHP</a> — MIT</li>
+          <li><a href="https://github.com/kaitai-io/kaitai_struct_python_runtime">Python</a> — MIT</li>
+          <li><a href="https://github.com/kaitai-io/kaitai_struct_ruby_runtime">Ruby</a> — MIT</li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
I expected that the list of runtime libraries with their licenses will have clickable links to their repositories, and I found that they don't. So I think it makes sense to add them.

_Believe it or not, the homepage is the entry point for all the new potential users and they're making a decision if they're interested in the project or not. And every annoyance will (at least unconsciously) affect their opinion. Speaking of which, I personally don't like the design much, but there unfortunately isn't much I can do with it. And it looks like we're ashamed of our own logo, it can be spotted only on the home page but nowhere else. And I don't think it's wise to have a logo with colored solid (non-transparent) background, because the brown square envelope looks weird almost everywhere. It's annoying to deal with these problems even in such an open-source no-budget project like this, but it might help if we want more users_ 😃 (you don't have to respond to this paragraph, just some ideas to think about) 

And we should maybe also update the list: runtimes for Go, Nim, Rust and Swift are missing. They might have incomplete support, but I think this isn't a reason to exclude them. Maybe the presence will motivate some developer to contribute, because they will see that some progress in his favorite language has been already done 🙂