### PR TITLE
Fix usage example to work in Python 3

### DIFF
--- a/index.md
+++ b/index.md
@@ -271,8 +271,8 @@ print("height = " . $g-&gt;logicalScreen()-&gt;imageHeight() . "\n");</code></pr
         <div role="tabpanel" class="tab-pane" id="example-python">
           <pre><code class="python">g = Gif.from_file("path/to/some.gif")
 
-print "width = %d" % (g.logical_screen.image_width)
-print "height = %d" % (g.logical_screen.image_height)</code></pre>
+print("width = %d" % (g.logical_screen.image_width))
+print("height = %d" % (g.logical_screen.image_height))</code></pre>
         </div>
         <div role="tabpanel" class="tab-pane" id="example-ruby">
           <pre><code class="ruby">g = Gif.from_file("path/to/some.gif")


### PR DESCRIPTION
The Python example at https://kaitai.io/#quick-start doesn't work in Python 3, because it uses the `print` statement, which has been replaced with a `print()` function in Python 3: https://docs.python.org/3/whatsnew/3.0.html#print-is-a-function