### PR TITLE
Add missing runtime libraries and mark them as WIP

### DIFF
--- a/index.md
+++ b/index.md
@@ -409,16 +409,21 @@ sudo apt-get install kaitai-struct-compiler</pre>
         <ul>
           <li><a href="https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime">C++/STL</a> — MIT</li>
           <li><a href="https://github.com/kaitai-io/kaitai_struct_csharp_runtime">C#</a> — MIT</li>
+          <li><a href="https://github.com/kaitai-io/kaitai_struct_go_runtime">Go <i class="fa fa-wrench"></i></a> — MIT</li>
           <li><a href="https://github.com/kaitai-io/kaitai_struct_java_runtime">Java</a> — MIT</li>
           <li><a href="https://github.com/kaitai-io/kaitai_struct_javascript_runtime">JavaScript</a> — Apache v2</li>
           <li><a href="https://github.com/kaitai-io/kaitai_struct_lua_runtime">Lua</a> — MIT</li>
+          <li><a href="https://github.com/kaitai-io/kaitai_struct_nim_runtime">Nim <i class="fa fa-wrench"></i></a> — MIT</li>
           <li><a href="https://github.com/kaitai-io/kaitai_struct_perl_runtime">Perl</a> — MIT</li>
           <li><a href="https://github.com/kaitai-io/kaitai_struct_php_runtime">PHP</a> — MIT</li>
           <li><a href="https://github.com/kaitai-io/kaitai_struct_python_runtime">Python</a> — MIT</li>
           <li><a href="https://github.com/kaitai-io/kaitai_struct_ruby_runtime">Ruby</a> — MIT</li>
+          <li><a href="https://github.com/kaitai-io/kaitai_struct_rust_runtime">Rust <i class="fa fa-wrench"></i></a> — MIT</li>
+          <li><a href="https://github.com/kaitai-io/kaitai_struct_swift_runtime">Swift <i class="fa fa-wrench"></i></a> — MIT</li>
         </ul>
       </li>
     </ul>
+    <p><i class="fa fa-wrench"></i> — work-in-progress</p>
   </div>
 </section>
 


### PR DESCRIPTION
@GreyCat 
As suggested in https://github.com/kaitai-io/kaitai-io.github.io/pull/7#issuecomment-586921298:

> > And we should maybe also update the list: runtimes for Go, Nim, Rust and Swift are missing.
>
> Also makes perfect sense. Let's **add these** clearly labelled as **work-in-progress** — that will both raise the image and assist in people's finding others work before starting their own?

However, it's not clear where is the boundary between the "normal" ready-to-use runtime and the one with the status work-in-progress. Rust and Swift runtimes are clearly WIP, but both Go and Nim currently pass ~70% of our tests, which basically means that it's quite usable even in production, if one doesn't need advanced (e.g. circular) imports or validation checks. So maybe we could remove the wrench icon next to those two.